### PR TITLE
Handle missing courier in UI

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,14 +2,18 @@ from flask import Flask, render_template, request
 from tracking import fetch_status
 
 app = Flask(__name__)
+APP_VERSION = "v0.0.1"
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
     result = None
+    error = None
     if request.method == 'POST':
         tracking_number = request.form.get('tracking_number', '')
         result = fetch_status(tracking_number)
-    return render_template('index.html', result=result)
+        if result is None:
+            error = 'Courier could not be detected.'
+    return render_template('index.html', result=result, error=error, version=APP_VERSION)
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0')

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -17,11 +17,17 @@
         <input type="text" name="tracking_number" placeholder="Enter tracking number" required>
         <button type="submit">Track</button>
     </form>
+    {% if error %}
+    <p style="color: red;">{{ error }}</p>
+    {% endif %}
     {% if result %}
     <table>
         <tr><th>Courier</th><td>{{ result.courier }}</td></tr>
         <tr><th>Status</th><td>{{ result.status }}</td></tr>
     </table>
     {% endif %}
+    <footer style="margin-top:20px; text-align:center;">
+        Version {{ version }}
+    </footer>
 </body>
 </html>

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -15,5 +15,14 @@ class TestTracking(unittest.TestCase):
         info = tracking.fetch_status('000000000000')
         self.assertTrue(info is None or info.status == 'Unknown')
 
+    def test_fetch_status_invalid(self):
+        self.assertIsNone(tracking.fetch_status('invalid'))
+
+    def test_app_version_constant(self):
+        with open('src/app.py') as f:
+            contents = f.read()
+        self.assertIn("APP_VERSION = \"v0.0.1\"", contents)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- show an error message when courier detection fails
- extend `fetch_status` tests for invalid tracking number
- add `APP_VERSION` constant and display it in page footer

## Testing
- `PYTHONPATH=src python -m unittest discover -s tests`
